### PR TITLE
Adiciona Interface para classe BusConnection 

### DIFF
--- a/Seedwork.CQRS.Bus.sln
+++ b/Seedwork.CQRS.Bus.sln
@@ -1,14 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{22984ADC-1FF7-44F6-9B2B-6122F9A3E68B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seedwork.CQRS.Bus.Core", "src\Core\Seedwork.CQRS.Bus.Core.csproj", "{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seedwork.CQRS.Bus.Core", "src\Core\Seedwork.CQRS.Bus.Core.csproj", "{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F618B22D-AD1F-46D5-B5CA-02C71809CE10}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seedwork.CQRS.Bus.Core.Tests", "tests\Core\Seedwork.CQRS.Bus.Core.Tests.csproj", "{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seedwork.CQRS.Bus.Core.Tests", "tests\Core\Seedwork.CQRS.Bus.Core.Tests.csproj", "{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,37 +20,40 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x86.Build.0 = Debug|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x64.Build.0 = Release|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x86.Build.0 = Release|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x64.Build.0 = Debug|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x86.Build.0 = Debug|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x64.ActiveCfg = Release|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x64.Build.0 = Release|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x86.ActiveCfg = Release|Any CPU
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x64.Build.0 = Debug|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x86.Build.0 = Debug|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x64.ActiveCfg = Release|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x64.Build.0 = Release|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x86.ActiveCfg = Release|Any CPU
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x86.Build.0 = Release|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x64.Build.0 = Debug|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x86.Build.0 = Debug|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x64.ActiveCfg = Release|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x64.Build.0 = Release|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x86.ActiveCfg = Release|Any CPU
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2} = {22984ADC-1FF7-44F6-9B2B-6122F9A3E68B}
-		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC} = {F618B22D-AD1F-46D5-B5CA-02C71809CE10}
+		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0} = {22984ADC-1FF7-44F6-9B2B-6122F9A3E68B}
+		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6} = {F618B22D-AD1F-46D5-B5CA-02C71809CE10}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4594CC44-F51B-404F-AA3D-43B4304BC4C9}
 	EndGlobalSection
 EndGlobal

--- a/Seedwork.CQRS.Bus.sln
+++ b/Seedwork.CQRS.Bus.sln
@@ -1,15 +1,14 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{22984ADC-1FF7-44F6-9B2B-6122F9A3E68B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seedwork.CQRS.Bus.Core", "src\Core\Seedwork.CQRS.Bus.Core.csproj", "{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seedwork.CQRS.Bus.Core", "src\Core\Seedwork.CQRS.Bus.Core.csproj", "{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F618B22D-AD1F-46D5-B5CA-02C71809CE10}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seedwork.CQRS.Bus.Core.Tests", "tests\Core\Seedwork.CQRS.Bus.Core.Tests.csproj", "{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seedwork.CQRS.Bus.Core.Tests", "tests\Core\Seedwork.CQRS.Bus.Core.Tests.csproj", "{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,40 +19,37 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x64.Build.0 = Debug|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Debug|x86.Build.0 = Debug|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x64.ActiveCfg = Release|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x64.Build.0 = Release|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x86.ActiveCfg = Release|Any CPU
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0}.Release|x86.Build.0 = Release|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x64.Build.0 = Debug|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Debug|x86.Build.0 = Debug|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x64.ActiveCfg = Release|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x64.Build.0 = Release|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x86.ActiveCfg = Release|Any CPU
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{1F8672F0-60FD-4CA1-ACF4-F6280A25BAC0} = {22984ADC-1FF7-44F6-9B2B-6122F9A3E68B}
-		{2219B2AF-5E9B-45DE-8A4F-0D405AB7A1E6} = {F618B22D-AD1F-46D5-B5CA-02C71809CE10}
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x64.Build.0 = Debug|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Debug|x86.Build.0 = Debug|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x64.ActiveCfg = Release|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x64.Build.0 = Release|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x86.ActiveCfg = Release|Any CPU
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2}.Release|x86.Build.0 = Release|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Debug|x86.Build.0 = Debug|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x64.Build.0 = Release|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x86.ActiveCfg = Release|Any CPU
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {4594CC44-F51B-404F-AA3D-43B4304BC4C9}
+	GlobalSection(NestedProjects) = preSolution
+		{6AB77A43-6519-4409-B7BC-46BDBDB96AD2} = {22984ADC-1FF7-44F6-9B2B-6122F9A3E68B}
+		{E8FBCCDE-E4FD-48EA-9EC0-B774568744AC} = {F618B22D-AD1F-46D5-B5CA-02C71809CE10}
 	EndGlobalSection
 EndGlobal

--- a/src/Core/BusConnection.cs
+++ b/src/Core/BusConnection.cs
@@ -19,7 +19,7 @@ namespace Seedwork.CQRS.Bus.Core
 
     public delegate void PublishFailed(IEnumerable<BatchItem> items, Exception exception);
 
-    public class BusConnection : IDisposable
+    public class BusConnection : IBusConnection
     {
         private static volatile object _sync = new object();
         private readonly IConnectionFactory _connectionFactory;

--- a/src/Core/Configurations/BusInitializer.cs
+++ b/src/Core/Configurations/BusInitializer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Framing.Impl;
 
 namespace Seedwork.CQRS.Bus.Core.Configurations
 {
@@ -24,7 +26,8 @@ namespace Seedwork.CQRS.Bus.Core.Configurations
                 .AddSingleton(BusConnectionString.Create(options.ConnectionString, options.ValidateCertificate))
                 .AddSingleton(typeof(IBusSerializer), options.SerializerImplementationType)
                 .AddSingleton<IRetryBehavior>(options.RetryBehavior)
-                .AddSingleton<BusConnection>();
+                .AddSingleton<IConnection, Connection>()
+                .AddSingleton<IBusConnection, BusConnection>();
 
             if (options.LoggerImplementationType != null)
             {

--- a/src/Core/Configurations/BusInitializer.cs
+++ b/src/Core/Configurations/BusInitializer.cs
@@ -15,7 +15,7 @@ namespace Seedwork.CQRS.Bus.Core.Configurations
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             if (configure == null) throw new ArgumentNullException(nameof(configure));
-            
+
             var builder = new BusInitializerOptionsBuilder(configuration);
 
             configure(builder);
@@ -26,8 +26,8 @@ namespace Seedwork.CQRS.Bus.Core.Configurations
                 .AddSingleton(BusConnectionString.Create(options.ConnectionString, options.ValidateCertificate))
                 .AddSingleton(typeof(IBusSerializer), options.SerializerImplementationType)
                 .AddSingleton<IRetryBehavior>(options.RetryBehavior)
-                .AddSingleton<IConnection, Connection>()
-                .AddSingleton<IBusConnection, BusConnection>();
+                .AddSingleton<IBusConnection, BusConnection>()
+                .AddSingleton(typeof(BusConnection));
 
             if (options.LoggerImplementationType != null)
             {

--- a/src/Core/IBusConnection.cs
+++ b/src/Core/IBusConnection.cs
@@ -10,8 +10,8 @@ namespace Seedwork.CQRS.Bus.Core
     {
         void Declare(Exchange exchange, Queue queue, params RoutingKey[] routingKeys);
 
-        public void Subscribe<T>(Exchange exchange, Queue queue, RoutingKey routingKey, ushort prefetchCount,
-                                 Func<IServiceScope, Message<T>, Task> action, bool autoAck = true);
+        void Subscribe<T>(Exchange exchange, Queue queue, RoutingKey routingKey, ushort prefetchCount,
+                          Func<IServiceScope, Message<T>, Task> action, bool autoAck = true);
 
         void Publish(Exchange exchange, Queue queue, RoutingKey routingKey, Message message);
 
@@ -28,12 +28,6 @@ namespace Seedwork.CQRS.Bus.Core
         event PublishSuccessed PublishSuccessed;
 
         event PublishFailed PublishFailed;
-
-        IConnection PublisherConnection { get; }
-
-        IConnection ConsumerConnection { get; }
-
-        new void Dispose();
 
         void Flush();
     }

--- a/src/Core/IBusConnection.cs
+++ b/src/Core/IBusConnection.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using RabbitMQ.Client;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Seedwork.CQRS.Bus.Core
+{
+    public interface IBusConnection : IDisposable
+    {
+        void Declare(Exchange exchange, Queue queue, params RoutingKey[] routingKeys);
+
+        public void Subscribe<T>(Exchange exchange, Queue queue, RoutingKey routingKey, ushort prefetchCount,
+                                 Func<IServiceScope, Message<T>, Task> action, bool autoAck = true);
+
+        void Publish(Exchange exchange, Queue queue, RoutingKey routingKey, Message message);
+
+        void Publish(Exchange exchange, Queue queue, RoutingKey routingKey, object data);
+
+        void Publish(Exchange exchange, RoutingKey routingKey, object notification);
+
+        void PublishBatch(Exchange exchange, Queue queue, RoutingKey routingKey,
+                          IEnumerable<object> notification);
+
+        void PublishBatch(Exchange exchange, Queue queue, RoutingKey routingKey,
+                          IEnumerable<Message> messages);
+
+        event PublishSuccessed PublishSuccessed;
+
+        event PublishFailed PublishFailed;
+
+        IConnection PublisherConnection { get; }
+
+        IConnection ConsumerConnection { get; }
+
+        new void Dispose();
+
+        void Flush();
+    }
+}

--- a/tests/Core/IntegrationTests/BusConnectionTests.cs
+++ b/tests/Core/IntegrationTests/BusConnectionTests.cs
@@ -294,7 +294,7 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
                 })
                 .BuildServiceProvider();
 
-            var connection = serviceProvider.GetService<BusConnection>();
+            var connection = serviceProvider.GetService<IBusConnection>();
 
             var exchange = Exchange.Default;
             var queue = Queue.Create(Guid.NewGuid().ToString());

--- a/tests/Core/IntegrationTests/BusConnectionTests.cs
+++ b/tests/Core/IntegrationTests/BusConnectionTests.cs
@@ -164,7 +164,7 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
 
             _connectionFixture.Connection.MessageCount(retryQueue).Should().Be(1);
         }
-        
+
         [Fact]
         public void GivenConnectionWhenSubscribeAndThrowShouldRequeueOnRetryQueueTheRightMessage()
         {
@@ -202,7 +202,7 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
             message.Should().NotBeNull();
             message.Data.Should().Be(notification);
         }
-        
+
         [Fact]
         public void GivenConnectionWhenSubscribeAndFailShouldRequeueOnRetryQueueTheRightMessage()
         {
@@ -233,7 +233,7 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
             }, false);
 
             autoResetEvent.WaitOne(); // Wait for subscribe to execute.
-            
+
             consumerMessage.Fail(new Exception());
 
             autoResetEvent.WaitOne(); // Wait for retry message publishing.
@@ -277,12 +277,14 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
             callbackMessage.Should().Be(notification);
         }
 
-        [Fact]
-        public void GivenConnectionWhenRetryShouldUseConfiguredBehavior()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GivenConnectionWhenRetryShouldUseConfiguredBehavior(bool isConnectionInstantiatedByInterface)
         {
             var configuration = new ConfigurationBuilder()
                 .Build();
-            
+
             var retryBehaviorMock = new Mock<IRetryBehavior>();
             var serviceProvider = new ServiceCollection()
                 .AddBusCore(configuration, builder =>
@@ -294,13 +296,17 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
                 })
                 .BuildServiceProvider();
 
-            var connection = serviceProvider.GetService<IBusConnection>();
-
+            IBusConnection connection = null;
+            if(isConnectionInstantiatedByInterface)
+                connection = serviceProvider.GetService<IBusConnection>();
+            else
+                connection = serviceProvider.GetService<BusConnection>();
+            
             var exchange = Exchange.Default;
             var queue = Queue.Create(Guid.NewGuid().ToString());
             var routingKey = RoutingKey.Create(queue.Name.Value);
             BatchItem item = null;
-            
+
             connection.Publish(exchange, queue, routingKey, "Message");
 
             var autoResetEvent = new AutoResetEvent(false);
@@ -318,7 +324,7 @@ namespace Seedwork.CQRS.Bus.Core.Tests.IntegrationTests
             retryBehaviorMock.Setup(x => x.GetWaitTime(1))
                 .Returns(TimeSpan.FromMinutes(5))
                 .Verifiable();
-            
+
             connection.Subscribe<string>(exchange, queue, routingKey, 1, (scope, message) =>
             {
                 throw new Exception("Test");


### PR DESCRIPTION
Para facilitar testes unitários adicionada interface. Agora será mais facil mockar a classe e testá-la.

- Todos os testes unitários executaram com sucesso
- Todos os testes de integração executaram com sucesso
- Antes de abrir o PR foi testado DI em uma classe e o moq funcionou com exito.